### PR TITLE
add to automatic dependency installation steps; tidy up messaging

### DIFF
--- a/R/conda_greta_env.R
+++ b/R/conda_greta_env.R
@@ -3,18 +3,70 @@
 #' Helper function to install appropriate python packages and python version
 #'   for `greta`.
 #'
+#' @note This willl automatically install Miniconda (a minimal version of the
+#' Anaconda scientific software management system), create a 'conda' environment
+#' for greta named 'greta-env' with required python and python package versions,
+#' and forcibly switch over to using that conda environment. There should be no
+#' need to restart if this was successfull.
+#'
 #' @export
 create_conda_greta_env <- function(){
 
-  reticulate::conda_create(envname = "greta-env",
-                           python_version = "3.7")
+  # can we capture the output from all these installation steps, suppress them,
+  # but give the user the option to print them after the fact for debugging
+  # purposes?
 
-  reticulate::conda_install(envname = "greta-env",
-                           packages = c("numpy==1.16.4",
-                                        "tensorflow-probability==0.7.0",
-                                        "tensorflow==1.14.0"),
-                           pip = TRUE)
+  # install miniconda if needed
+  if (!have_conda()) {
+    reticulate::install_miniconda()
+  }
 
+  # create the greta conda environment with the required version of python
+  reticulate::conda_create(
+    envname = "greta-env",
+    python_version = "3.7"
+  )
+
+  # install the relevant python packages into the conda environment, using pip
+  reticulate::conda_install(
+    envname = "greta-env",
+    packages = c("numpy==1.16.4",
+                 "tensorflow-probability==0.7.0",
+                 "tensorflow==1.14.0")
+    # pip = TRUE
+  )
+
+  # # switch to using this greta environment now
+  # if (reticulate::)
+  # use_greta_conda_env()
+  #
+  # success <- check_tf_version()
+  #
+  # # evaluate installation and report back to the user
+  # if (success) {
+  #   message("greta dependencies successfully installed, no need to restart")
+  # } else {
+  #   message("installation of dependencies failed, complain to Nick Tierney")
+  # }
+  #
+  # invisible(success)
+
+  message(
+    "\nInstallation complete. Please open a fresh R session and load greta with:",
+    "\n\n  ",
+    "library(greta)",
+    "\n"
+  )
+
+}
+
+use_greta_conda_env <- function() {
+  reticulate::use_condaenv("greta-env", required = TRUE)
+}
+
+using_greta_conda_env <- function() {
+  config <- reticulate::py_discover_config()
+  grepl("greta-env", config$python)
 }
 
 have_greta_conda_env <- function(){

--- a/R/utils.R
+++ b/R/utils.R
@@ -85,22 +85,25 @@ check_tf_version <- function(alert = c("none",
 
   alert <- match.arg(alert)
 
-  valid_dependencies <- (have_greta_conda_env() && py_available() && have_tf() && have_tfp())
+  requirements_valid <- c(
+    python_exists = have_python(),
+    correct_tf = have_tf(),
+    correct_tfp = have_tfp()
+  )
 
-  if (!valid_dependencies) {
+  if (!all(requirements_valid)) {
 
     # if there was a problem, append the solution
       text <- paste0(
-        "\n\n",
         "We have detected that you do not have the greta conda environment ",
         "setup. You can create this using:",
-        "\n",
+        "\n\n\t",
         "create_conda_greta_env()",
-        "\n",
+        "\n\n",
         "and then call:",
-        "\n",
+        "\n\n\t",
         "library(greta)",
-        "\n",
+        "\n\n",
         "in a fresh R session that has not yet initialised Tensorflow.",
         "\n",
         "For more information, see PLACEHOLDER HELP FILE.",
@@ -115,7 +118,7 @@ check_tf_version <- function(alert = c("none",
            none = NULL)
   }
 
-  invisible(valid_dependencies)
+  invisible(all(requirements_valid))
 
 }
 


### PR DESCRIPTION
Some tweaks to tidy up the installation process.

```r
# wipe out the good environment
library(reticulate)
conda_remove("greta-env")
env <- tempfile("python-env-")
conda_create(env)
use_condaenv(env, required = TRUE)
reticulate::py_discover_config()

# try to run greta
library(greta)
x <- normal(0, 1)

# run this, as requested
create_conda_greta_env()

# <restart here> as requested
library(greta)
x <- normal(0, 1)
m <- model(x)
draws <- mcmc(m)

# wahoo!
```

This also installs miniconda if they don't already have it. NB if you run `reticulate::install_miniconda()` when you already have miniconda in the usual location, you end up with two conda installations which can be awkward. That shouldn't be an issue for greta users though.

If we can work out at which stage Python is initialised, we may be able to do away with the need to restart. That's not critical though.

It would also be cool if we could capture all the conda installation text, suppress during installation (replacing with our own shorter messages on progress), but make available to the user on completion if needed ('run `installation_messages()` to get all outputs for debugging purposes').

Note: this would be expected to work on CI, since I don't check that they are using the greta-env conda environment. That only gets forced if they don't have a working installation already. That also means advanced users can install their own set up in a different environment if they want!