### PR TITLE
make as_tf_function work in greta.dynamics

### DIFF
--- a/R/calculate.R
+++ b/R/calculate.R
@@ -466,9 +466,10 @@ calculate_target_tensor_list <- function(
 
   tfe <- dag$tf_environment
 
-  # add the batch size to the data list
+  # add the batch size to the data list and the greta stash (for sub-dags)
   batch_size <- ifelse(stochastic, as.integer(nsim), 1L)
   assign("batch_size", batch_size, envir = tfe)
+  assign("batch_size", batch_size, envir = greta_stash)
 
   values <- lapply(values, add_first_dim)
   values <- lapply(values, tile_first_dim, batch_size)

--- a/R/dag_class.R
+++ b/R/dag_class.R
@@ -247,6 +247,11 @@ dag_class <- R6Class(
           batch_size <- tf$shape(self$tf_environment$free_state)[0]
         )
       }
+
+      # put this in the greta stash, so it can be accessed by other (sub-)dags
+      # if needed, e.g. when using as_tf_function()
+      assign("batch_size", self$tf_environment$batch_size, envir = greta_stash)
+
     },
 
     define_free_state = function(type = c("variable", "placeholder"),

--- a/R/utils.R
+++ b/R/utils.R
@@ -110,10 +110,10 @@ fl <- function(x) {
   tf$constant(x, dtype = tf_float())
 }
 
-# get the tensor for the batch size in the dag currently defining (since it's
-# not alway possible to pass the dag in)
+# get the tensor for the batch size in the dag recently defined (since it's
+# not always possible to pass the dag in)
 get_batch_size <- function() {
-  options()$greta_batch_size
+  greta_stash$batch_size
 }
 
 # coerce an integer(ish) vector to a list as expected in tensorflow shape
@@ -694,11 +694,13 @@ as_tf_function <- function(r_fun, ...) {
       # `tf.function`.
     # use the default graph, so that it can be overwritten when this is called?
     # alternatively fetch from above, or put it in greta_stash?
-    sub_dag$tf_graph <- tf$compat$v1$get_default_graph()
+    # sub_dag$tf_graph <- tf$compat$v1$get_default_graph()
     sub_tfe <- sub_dag$tf_environment
 
     # pass on the batch size, used when defining data
     #  - how many chains or whatever to use
+    # get the batch size from the input tensors - it should be written to the
+    # stash by the main dag - but only if a main dag is defined. What about in calculate?
     sub_tfe$batch_size <- get_batch_size()
 
     # set the input tensors as the values for the dummy greta arrays in the new


### PR DESCRIPTION
as_tf_function() was failing (at least when used in the experimental branches of greta.dynamics) as the batch size was not being passed into the sub-dag used to define the function. 

This patch explicitly places the batch size in greta_stash when it is placed in the main dag's tf_environment, and when it is defined in calculate(), which seems to work.